### PR TITLE
Allow search engine indexing and link following

### DIFF
--- a/resources/html/index.html
+++ b/resources/html/index.html
@@ -24,7 +24,6 @@
   <meta name="description" content="Whiplash is a free game that allows you to place virtual bets on live competitive events, purely for entertainment purposes. No real money will be paid out.">
   <!-- TODO (paulshryock): Add linked stylesheet -->
   <!-- <link rel="stylesheet" href="/dist/css/bundle.min.css"> -->
-  <!-- TODO (paulshryock): Update http headers to allow search engine indexing and link following -->
   <!-- Allow search engines to index the page and follow links -->
   <meta name="robots" content="index, follow">
 


### PR DESCRIPTION
### HTML meta tags:

- [x] Update meta description
- [x] Update robots meta tag to allow search engine indexing and link following

The above mentioned HTML [meta tag][meta-tag] is sufficient to request search engines to index the page and follow links.

### HTTP header:

> You do not need to use both meta robots and the x-robots-tag on the same page – doing so would be redundant.
> -- [moz.com][moz]

### What about `robots.txt`?

Using `robots.txt` would [prevent the page from being crawled][robots-txt], so the meta tag or HTTP header would never even be discovered, and would be useless. So if we're using a meta tag or HTTP header, skip `robots.txt`.

> All meta directives (robots or otherwise) are discovered when a URL is crawled. This means that if a robots.txt file disallows the URL from crawling, any meta directive on a page (either in the HTML or the HTTP header) will not be seen and will, effectively, be ignored.
> 
> In most cases, using a meta robots tag with parameters "noindex, follow" should be employed as a way to to restrict crawling or indexation instead of using robots.txt file disallows.
> -- [moz.com][moz]

---

Closes #64

[meta-tag]: https://developers.google.com/search/reference/robots_meta_tag#robotsmeta
[moz]: https://moz.com/learn/seo/robots-meta-directives
[robots-txt]: https://developers.google.com/search/reference/robots_meta_tag#combining