### PR TITLE
Increase leaderboard font size

### DIFF
--- a/resources/css/components/leaderboard.css
+++ b/resources/css/components/leaderboard.css
@@ -102,7 +102,7 @@
     padding: 0.25em 0.5em;
     color: $dark-white;
     font-family: $font-stack-code;
-    font-size: 0.5rem;
+    font-size: 0.75rem;
 
     + .leaderboard__td {
       border-left: 1px solid $light-black;


### PR DESCRIPTION
@jonwalch I'd strongly advise against bringing any font size as low as `0.5rem`, as it causes accessibility and UX issues, especially at smaller screen sizes. I would never go below `0.75rem` for anything, and even then only that small in rare cases like "fine print" and copyright text.